### PR TITLE
Add cron jitter and terms disclaimer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,5 @@ STREET_NAME=Norwich Street
 POSTCODE=NR1 1..
 # Optional: run on internal schedule instead of once
 # CRON_PATTERN=0 8 * * *
+# Optional: override cron jitter (seconds, default 60). Set to 0 to disable (not recommended).
+# CRON_JITTER_MAX_SECONDS=60

--- a/README.md
+++ b/README.md
@@ -14,5 +14,11 @@ docker compose run --rm scraper
 ## Scheduling
 
 By default the scraper runs once so it can be triggered by an external cron.
-Set `CRON_PATTERN` in the environment (e.g. `CRON_PATTERN="0 8 * * *"`) to
-have the container run the scraper on its own internal schedule.
+Before each scrape a small random delay (jitter) of up to 60 seconds is applied
+to avoid hitting the service at a perfectly predictable time. Override this with
+`CRON_JITTER_MAX_SECONDS` (set to `0` to disable), but this is **not recommended**.
+Set `CRON_PATTERN` in the environment (e.g. `CRON_PATTERN="0 8 * * *"`) to have
+the container run the scraper on its own internal schedule, where the same
+jitter is applied before every run. Whatever scheduling approach you use,
+ensure you abide by WhitespaceWS terms and conditions regarding scraping
+intervals.


### PR DESCRIPTION
## Summary
- apply random jitter before every scrape, including single-run mode
- document default 60s `CRON_JITTER_MAX_SECONDS`
- remind users to observe WhitespaceWS timing rules

## Testing
- `python -m py_compile scrape.py`


------
https://chatgpt.com/codex/tasks/task_e_689c8289154c832b9064cec97bd79385