### PR TITLE
Ensure immediate run even when scheduled

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ to avoid hitting the service at a perfectly predictable time. Override this with
 `CRON_JITTER_MAX_SECONDS` (set to `0` to disable), but this is **not recommended**.
 Set `CRON_PATTERN` in the environment (e.g. `CRON_PATTERN="0 8 * * *"`) to have
 the container run the scraper on its own internal schedule, where the same
-jitter is applied before every run. Whatever scheduling approach you use,
-ensure you abide by WhitespaceWS terms and conditions regarding scraping
-intervals.
+jitter is applied before every run. An initial scrape is always performed on
+startup so that debug output and calendar files are produced immediately.
+Whatever scheduling approach you use, ensure you abide by WhitespaceWS terms
+and conditions regarding scraping intervals.
 
 ## Event retention
 

--- a/scrape.py
+++ b/scrape.py
@@ -183,8 +183,10 @@ async def main():
         print(f"Initial sleep for {initial_jitter:.0f}s")
         await asyncio.sleep(initial_jitter)
 
+    # Always perform an initial run so DEBUG output is shown and the calendar
+    # is generated even when a CRON pattern is supplied.
+    await run()
     if not pattern:
-        await run()
         return
 
     from croniter import croniter


### PR DESCRIPTION
## Summary
- always execute an initial scrape before scheduling future runs
- document that a startup scrape occurs even with `CRON_PATTERN`

## Testing
- `python -m py_compile scrape.py`


------
https://chatgpt.com/codex/tasks/task_e_689ca06c7238832b9f7ad965c7c7113d