### PR TITLE
Add local execution option and improve docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,8 +7,8 @@ STREET_NAME=Example Street
 # Property postcode (UK format, e.g. NR3 1HU)
 POSTCODE=NR3 1HU
 
-# Optional: override calendar output path (default /output/bins.ics)
-# OUTPUT_PATH=/output/bins.ics
+# Optional: override calendar output path (default ${LOCAL_OUTPUT_DIR}/bins.ics)
+# OUTPUT_PATH=/var/www/html/bins.ics
 
 # Optional: run on an internal schedule e.g. "0 8 * * *"
 # CRON_PATTERN=
@@ -22,5 +22,6 @@ POSTCODE=NR3 1HU
 # Optional: enable debug output
 # DEBUG=1
 
-# Optional: host directory for the generated file (default /var/www/html)
+# Optional: host directory for the generated file (default /var/www/html).
+# Used by docker compose and local runs when OUTPUT_PATH is not set.
 # LOCAL_OUTPUT_DIR=/var/www/html

--- a/README.md
+++ b/README.md
@@ -2,18 +2,40 @@
 
 Norwich City Council moved to WhitespaceWS to fulfil their waste services and took down the old map logic
 
-# To use..
+# Setup
 
-Copy `.env.example` to `.env` and edit the environment variables, then:
+Copy `.env.example` to `.env` and edit the environment variables.
+
+## Docker
 
 ```
 docker compose build
 docker compose run --rm scraper
-# bins.ics -> /output/bins.ics
+# bins.ics -> ${LOCAL_OUTPUT_DIR:-/var/www/html}/bins.ics
 ```
 
-Set `LOCAL_OUTPUT_DIR` in `.env` to control the host directory for the generated
-file. It defaults to `/var/www/html`.
+`LOCAL_OUTPUT_DIR` controls the host directory for the generated file.
+
+## Local Python
+
+Create a virtual environment and install dependencies:
+
+```
+python -m venv .venv
+. .venv/bin/activate
+pip install -r requirements.txt
+playwright install
+```
+
+Run the scraper:
+
+```
+python scrape.py
+# bins.ics -> ${LOCAL_OUTPUT_DIR:-/var/www/html}/bins.ics
+```
+
+The script automatically loads the `.env` file. Schedule it with your own
+cron job or systemd timer, or set `CRON_PATTERN` for built-in scheduling.
 
 ## Environment variables
 
@@ -25,11 +47,11 @@ file. It defaults to `/var/www/html`.
 
 ### Optional
 
-- `OUTPUT_PATH` – override calendar output path (default `/output/bins.ics`)
+- `OUTPUT_PATH` – override calendar output path (default `${LOCAL_OUTPUT_DIR}/bins.ics`; inside the container the default is `/output/bins.ics`)
 - `CRON_PATTERN` – run on an internal schedule when set, e.g. `0 8 * * *` for every day at 8:00am UTC / 9:00am BST
 - `CRON_JITTER_MAX_SECONDS` – random delay before each run (default `60`, set `0` to disable – not recommended)
 - `KEEP_DAYS` – past event retention: `-1` keeps all (default), `0` keeps none, `N` keeps last `N` days
-- `LOCAL_OUTPUT_DIR` – host directory for the generated file (default `/var/www/html`)
+- `LOCAL_OUTPUT_DIR` – host directory for the generated file used by docker compose and local runs (default `/var/www/html`)
 - `DEBUG` – enable verbose logging of the scraping steps
 
 ## Scheduling

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 ics==0.7.2
 playwright==1.46.0
 croniter==6.0.0
+python-dotenv==1.0.1

--- a/scrape.py
+++ b/scrape.py
@@ -2,13 +2,16 @@
 import os, re, hashlib, asyncio, random
 from pathlib import Path
 from datetime import datetime, timedelta, date, UTC
+from dotenv import load_dotenv
 from ics import Calendar, Event
 from playwright.async_api import async_playwright
 
-TARGET_URL  = os.getenv("TARGET_URL", "https://bnr-wrp.whitespacews.com/#!")
-OUTPUT_PATH = Path(os.getenv("OUTPUT_PATH", "/output/bins.ics"))
-HEADLESS    = os.getenv("HEADLESS", "1") == "1"
-DEBUG       = os.getenv("DEBUG", "0").lower() not in ("0", "false", "")
+load_dotenv()
+TARGET_URL         = os.getenv("TARGET_URL", "https://bnr-wrp.whitespacews.com/#!")
+DEFAULT_OUTPUT_DIR = Path(os.getenv("LOCAL_OUTPUT_DIR", "/var/www/html"))
+OUTPUT_PATH        = Path(os.getenv("OUTPUT_PATH") or DEFAULT_OUTPUT_DIR / "bins.ics")
+HEADLESS           = os.getenv("HEADLESS", "1") == "1"
+DEBUG              = os.getenv("DEBUG", "0").lower() not in ("0", "false", "")
 
 def debug(*args):
     if DEBUG:


### PR DESCRIPTION
## Summary
- allow running the scraper locally by loading `.env` and deriving the output path from `LOCAL_OUTPUT_DIR`
- document Docker and local Python workflows
- include `python-dotenv` dependency and update example env file

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile scrape.py`


------
https://chatgpt.com/codex/tasks/task_e_689ca709196c832ba64aff4bbe29cf3d