### PR TITLE
Ensure ICS events are full-day without timezone shifts

### DIFF
--- a/scrape.py
+++ b/scrape.py
@@ -86,7 +86,7 @@ def add_events(cal: Calendar, items: list[tuple[str, date]]) -> int:
         debug(f"Adding event: {summary} on {d}")
         ev = Event(name=summary)
         ev.begin = d
-        ev.end = d + timedelta(days=1)
+        ev.make_all_day()
         ev.uid = make_uid(summary, d)
         ev.created = ev.last_modified = datetime.now(UTC)
         cal.events.add(ev); added += 1


### PR DESCRIPTION
## Summary
- mark generated calendar events as all-day so they don't drift by an hour in BST

## Testing
- `python -m py_compile scrape.py`
- `python - <<'PY'
from datetime import date
from scrape import add_events
from ics import Calendar
cal = Calendar()
add_events(cal, [("Test", date(2024,3,29))])
print(cal.serialize())
PY`

------
https://chatgpt.com/codex/tasks/task_e_689cb1c45908832b9dd92c37724b23f7